### PR TITLE
fix: superfluous change to trigger new release

### DIFF
--- a/cypress/integration/test.js
+++ b/cypress/integration/test.js
@@ -4,7 +4,6 @@ context('Actions', () => {
   })
 
   it('.type() - type into a DOM element', () => {
-    // https://on.cypress.io/type
 
     cy.get('#search').type('cool').should('have.value', 'cool')
 


### PR DESCRIPTION
#2 didn't trigger a release because:

> npm ERR! You do not have permission to publish "search-with-your-keyboard". Are you logged in as the correct user?

I did `npm owner add electron search-with-your-keyboard`. Should be good now.