### PR TITLE
slash key behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = function searchWithYourKeyboard (inputSelector, hitsSelector) {
         if (event.target !== input) {
           input.focus()
           input.select()
+          event.preventDefault() // prevent slash from being typed into input
         }
         break
 


### PR DESCRIPTION
In #2, a change was made to hand `keydown` events instead of `keyup`, in order to be able to avoid arrow keys scrolling the window up and down. That change caused a regression where the pressing the `/` slash key adds a `/` to the input after focusing it. This should fix that.