### PR TITLE
only hijack up and down arrows when query exists

### DIFF
--- a/demo.css
+++ b/demo.css
@@ -26,6 +26,7 @@ main {
   border-radius: 3px;
   display: block;
   width: 100%;
+  height: 200px;
   border: 1px solid #DDD;
   padding: 10px;
   margin: 10px 0;

--- a/demo.js
+++ b/demo.js
@@ -17,11 +17,20 @@ const $main = html`
     <div class="hit"><a href="http://en.wikipedia.org/wiki/apples">apples</a></div>
     <div class="hit"><a href="http://en.wikipedia.org/wiki/bananas">bananas</a></div>
     <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
+    <div class="hit"><a href="http://en.wikipedia.org/wiki/carrots">carrots</a></div>
   </div>
 </main>
 `
 
 document.addEventListener('DOMContentLoaded', () => {
   document.body.appendChild($main)
-  searchWithYourKeyboard('#search', '#hits')
+  searchWithYourKeyboard('#search', '.hit')
 })

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function searchWithYourKeyboard (inputSelector, hitsSelector) {
     if (!event || !event.code || !targetEventCodes.includes(keycode(event))) return
 
     const hits = Array.from(document.querySelectorAll(hitsSelector))
+    const queryExists = Boolean(input && input.value && input.value.length > 0)
 
     switch (keycode(event)) {
       case 'esc':
@@ -46,6 +47,8 @@ module.exports = function searchWithYourKeyboard (inputSelector, hitsSelector) {
         break
 
       case 'up':
+        if (!queryExists) return
+
         // search input is the zero index (don't go beyond it)
         if (activeIndex > 0) {
           activeIndex--
@@ -55,6 +58,8 @@ module.exports = function searchWithYourKeyboard (inputSelector, hitsSelector) {
         break
 
       case 'down':
+        if (!queryExists) return
+
         // last hit is the last index (don't go beyond it)
         if (activeIndex < hits.length) {
           activeIndex++


### PR DESCRIPTION
If query exists, arrow keys cycle through hit list. If query does not exist, arrow keys have normal behavior (scrolling the page).