### PR TITLE
feat: open links in new window if modifier key is pressed

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,26 @@ module.exports = function searchWithYourKeyboard (inputSelector, hitsSelector) {
     const hits = getCurrentHits()
     const queryExists = Boolean(input && input.value && input.value.length > 0)
 
+    if (event.ctrlKey && event.keyCode === 13 && activeIndex > 0) {
+      const hit = hits[activeIndex - 1]
+      if (!hit) {
+        return
+      }
+      const link = hit.querySelector('a')
+      if (!link) {
+        return
+      }
+      const href = link.getAttribute('href')
+      if (!href) {
+        return
+      }
+      window.open(href, '_blank')
+      // NOTE: The `window.focus()` method not work correctly
+      // on some browser or OS. It don't focus window in
+      // Chrome browser.
+      window.focus()
+    }
+
     switch (keycode(event)) {
       case 'esc':
         input.focus()
@@ -69,8 +89,11 @@ module.exports = function searchWithYourKeyboard (inputSelector, hitsSelector) {
         break
 
       case 'enter':
-        // look for a link in the given hit, then visit it
-        if (activeIndex > 0) {
+        // If Ctrl key is pressed, we block using this case.
+        if (event.ctrlKey) {
+          break
+        } else if (activeIndex > 0) {
+          // look for a link in the given hit, then visit it
           const hit = hits[activeIndex - 1]
           if (!hit) return
           const link = hit.querySelector('a')

--- a/index.js
+++ b/index.js
@@ -30,26 +30,6 @@ module.exports = function searchWithYourKeyboard (inputSelector, hitsSelector) {
     const hits = getCurrentHits()
     const queryExists = Boolean(input && input.value && input.value.length > 0)
 
-    if (event.ctrlKey && event.keyCode === 13 && activeIndex > 0) {
-      const hit = hits[activeIndex - 1]
-      if (!hit) {
-        return
-      }
-      const link = hit.querySelector('a')
-      if (!link) {
-        return
-      }
-      const href = link.getAttribute('href')
-      if (!href) {
-        return
-      }
-      window.open(href, '_blank')
-      // NOTE: The `window.focus()` method not work correctly
-      // on some browser or OS. It don't focus window in
-      // Chrome browser.
-      window.focus()
-    }
-
     switch (keycode(event)) {
       case 'esc':
         input.focus()
@@ -89,18 +69,26 @@ module.exports = function searchWithYourKeyboard (inputSelector, hitsSelector) {
         break
 
       case 'enter':
-        // If Ctrl key is pressed, we block using this case.
-        if (event.ctrlKey) {
-          break
-        } else if (activeIndex > 0) {
-          // look for a link in the given hit, then visit it
+        // look for a link in the given hit, then visit it
+        if (activeIndex > 0) {
           const hit = hits[activeIndex - 1]
           if (!hit) return
           const link = hit.querySelector('a')
           if (!link) return
           const href = link.getAttribute('href')
           if (!href) return
-          window.location = href
+
+          // If `ctrlKey` is pressed, opens page in new window.
+          // In all other cases, we open the page in the same window.
+          if (event.ctrlKey) {
+            window.open(href, '_blank')
+            // NOTE: The `window.focus()` method not work correctly
+            // on some browser or OS. It don't focus window in
+            // Chrome browser.
+            window.focus()
+          } else {
+            window.location = href
+          }
         }
         break
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,11 @@
     "keycode": "^2.2.0"
   },
   "standard": {
-    "env": ["jest"],
-    "ignore": ["/cypress"]
+    "env": [
+      "jest"
+    ],
+    "ignore": [
+      "/cypress"
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-# search-with-your-keyboard 
+# search-with-your-keyboard
 
 > Add keyboard navigation to your existing client-side search interface.
 
 This module is designed to make [Algolia InstantSearch] results (aka "hits") navigable
-with a keyboard. It's not Algolia-specific though, and should work with any 
-search setup so long as it includes a search input and a list of 
+with a keyboard. It's not Algolia-specific though, and should work with any
+search setup so long as it includes a search input and a list of
 client-side-updated results.
 
 ## Behavior
@@ -16,6 +16,7 @@ Key | Action
 <kbd>down</kbd> | Adds an `active` class to the next (visible) hit. Only applies when the search input contains a value.
 <kbd>up</kbd> | Adds an `active` class to the previous (visible) hit. If already on the first search hit, the search input is focused. Only applies when the search input contains a value.
 <kbd>enter</kbd> | Sets `window.location` to the `href` of the first `<a>` tag in the current `.active` hit, if present.
+<kbd>cmdOrCtrl+Enter</kbd> | Opens the window in new tab and focus it.
 
 ## Installation
 
@@ -25,7 +26,7 @@ npm install search-with-your-keyboard
 
 ## Usage
 
-The module exports a single function that expects two CSS selector strings as 
+The module exports a single function that expects two CSS selector strings as
 arguments: one for the input element, one for the set of hit elements.
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Key | Action
 <kbd>down</kbd> | Adds an `active` class to the next (visible) hit. Only applies when the search input contains a value.
 <kbd>up</kbd> | Adds an `active` class to the previous (visible) hit. If already on the first search hit, the search input is focused. Only applies when the search input contains a value.
 <kbd>enter</kbd> | Sets `window.location` to the `href` of the first `<a>` tag in the current `.active` hit, if present.
-<kbd>cmdOrCtrl+Enter</kbd> | Opens the window in new tab and focus it.
+<kbd>cmdOrCtrl</kbd>+<kbd>Enter</kbd> | Opens the window in new tab and focus it.
 
 ## Installation
 


### PR DESCRIPTION
Opens new tab and focus it when `cmdOrCtrl+Enter` key is pressed.
Fixes #8. 

/cc @zeke 

### Demo

![perfgif](https://user-images.githubusercontent.com/24681191/43090182-5a5eaeca-8eaf-11e8-8a5d-92b6c8167dd2.gif)

